### PR TITLE
Fixes race condition causing false iOS declines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.1
+* Fixes false decline on iOS
+
 ## 2.5.0
 * update jvmToolchain(17) for Android
 

--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -521,6 +521,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
             action.fail()
             return
         }
+        self.answerCall = call
         self.configurAudioSession()
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(1200)) {
             self.configurAudioSession()
@@ -528,7 +529,6 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         call.hasConnectDidChange = { [weak self] in
             self?.sharedProvider?.reportOutgoingCall(with: call.uuid, connectedAt: call.connectedData)
         }
-        self.answerCall = call
         sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ACCEPT, self.data?.toJSON())
         if let appDelegate = UIApplication.shared.delegate as? CallkitIncomingAppDelegate {
             appDelegate.onAccept(call, action)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkit_incoming
 description: Flutter Callkit Incoming to show callkit screen in your Flutter app.
-version: 2.5.0
+version: 2.5.1
 homepage: https://github.com/hiennguyen92/flutter_callkit_incoming
 repository: https://github.com/hiennguyen92/flutter_callkit_incoming
 issue_tracker: https://github.com/hiennguyen92/flutter_callkit_incoming/issues


### PR DESCRIPTION
The race condition occurred like this:
1. User taps "Accept"
2. `CXAnswerCallAction` begins processing
3. Audio session change triggers a `CXEndCallAction`
4. The `CXEndCallAction` handler checks `self.answerCall`
5. If `self.answerCall` hadn't been set yet (because the `CXAnswerCallAction` hadn't finished), the system would interpret this as a decline action

By moving `self.answerCall = call` to the very beginning of the answer handler, we ensure that this flag is set before any audio session changes or other async operations can trigger the end call handler. This prevents the end call handler from misinterpreting the state as a decline action.

This is a common issue in iOS CallKit implementations because of how iOS manages the handoff between the system UI and the app's call handling. The audio session changes and state transitions happen very quickly and sometimes in an unexpected order, which is why setting state flags as early as possible is important for maintaining consistent behavior.